### PR TITLE
Fixed FB

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :get_item_id, only: [:show, :edit, :update, :destroy, :move_to_index]
+  before_action :move_to_login, only: [:new, :edit]
   before_action :move_to_index, only: [:edit]
 
 
@@ -55,7 +56,12 @@ class ItemsController < ApplicationController
   end
 
   def move_to_index
-    redirect_to root_path unless current_user && (current_user.id == @item.user_id)
-    redirect_to root_path if @item.purchase_record.present?
+    if @item.purchase_record.present? || (current_user && current_user.id != @item.user_id)
+      redirect_to root_path
+    end
+  end
+
+  def move_to_login
+    redirect_to new_user_session_path if current_user.nil?
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -2,7 +2,7 @@ class OrdersController < ApplicationController
   before_action :move_to_login, only: [:index]
   before_action :move_to_index, only: [:index, :create]
   def index
-    gon.public_key = ENV['PAYJP_PUBLIC_KEY']
+    gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
     @order = Order.new
   end
 
@@ -13,7 +13,8 @@ class OrdersController < ApplicationController
       @order.save
       redirect_to root_path
     else
-      render :index, status: :unprocessable_entity
+      gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
+      render 'index', status: :unprocessable_entity
     end
   end
 
@@ -38,7 +39,7 @@ class OrdersController < ApplicationController
   end
 
   def pay_item
-    Payjp.api_key = ENV['PAYJP_SECRET_KEY']
+    Payjp.api_key = ENV["PAYJP_SECRET_KEY"]
     Payjp::Charge.create(
       amount: @item.price,
       card: order_params[:token],

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -12,14 +12,14 @@ const pay = () => {
 
   const form = document.getElementById('charge-form')
   form.addEventListener("submit", (e) => {
-    payjp.createToken(numberElement).then(function(response){
-      if(response.error) {
+    payjp.createToken(numberElement).then(function (response) {
+      if (response.error) {
       } else {
         const token = response.id;
-        const renderDom = document.getElementById('charge-form');
-        const token0bj = `<input value=${token} name='token' type="hidden">`;
-        renderDom.insertAdjacentHTML("beforeend", token0bj);
-      };
+        const renderDom = document.getElementById("charge-form");
+        const tokenObj = `<input value=${token} name='token' type="hidden">`;
+        renderDom.insertAdjacentHTML("beforeend", tokenObj);
+      }
       numberElement.clear();
       expiryElement.clear();
       cvcElement.clear();

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,6 @@
 </head>
 
 <body>
-  <%= include_gon %>
   <%= yield %>
 
 </body>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,3 +1,5 @@
+<%= include_gon %>
+
 <%= render "shared/second-header"%>
 
 <div class='transaction-contents'>


### PR DESCRIPTION
# What 
FB修正
 ログアウト状態の場合は、商品出品ページへ遷移しようとすると、ログインページへ遷移すること
ログアウト状態でも商品出品ページへ遷移できてしまいます。

 ログイン状態の場合でも、自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移すること
自身が出品していない売却済み商品の商品情報編集ページへ遷移しようとすると、エラーページに遷移してしまいます。

 ログアウト状態の場合は、商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移すること
売却済み商品の商品情報編集ページへ遷移しようとすると、エラーページに遷移してしまいます。

 クレジットカード情報は必須であり、PAY.JPテストカードの情報で決済ができること
一度購入に失敗しエラーが出た後に、クレジットカード情報が入力できなくなってしまいます。どの段階でも入力できるよう修正しましょう。